### PR TITLE
Add .gitignore file to exclude winners.jsonl and losers.jsonl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+winners.jsonl
+losers.jsonl


### PR DESCRIPTION
We don't want other BBS's to be stuck with our old leaderboards now do we Tar?